### PR TITLE
fix: support self.frames["Id"] as pd.Series

### DIFF
--- a/opentimspy/opentims.py
+++ b/opentimspy/opentims.py
@@ -138,11 +138,11 @@ class OpenTIMS:
 
     @property
     def min_frame(self) -> int:
-        return self.frames["Id"][0]
+        return self.frames["Id"].min()
 
     @property
     def max_frame(self) -> int:
-        return self.frames["Id"][-1]
+        return self.frames["Id"].max()
 
     @property
     def frames_no(self) -> int:


### PR DESCRIPTION
in [timspy](https://github.com/MatteoLacki/timspy), OpenTIMS.frame is converted as a `pd.DataFrame`, in which `self.frames["Id"]` will be a `pd.Series` and do not support the `[-1]` action.  
https://github.com/MatteoLacki/timspy/blob/c9e69e530a002accd2093d0235034732e173836e/timspy/df.py#L14-L24

To use `.min()` and `.max()`, these functions can be more robust.