### PR TITLE
make use of the v2 version of tims_open so that recalibrated data is loaded

### DIFF
--- a/opentims++/bruker_api.h
+++ b/opentims++/bruker_api.h
@@ -19,6 +19,15 @@
 
 typedef uint64_t tims_open_fun_t(const char *path, uint32_t recalibration);
 
+enum pressure_compensation_strategy {
+    NoPressureCompensation = 0,
+    AnalyisGlobalPressureCompensation = 1,
+    PerFramePressureCompensation = 2,
+    PerFramePressureCompensationWithMissingReference = 3
+};
+typedef uint64_t tims_open_v2_fun_t(const char *path, uint32_t recalibration,
+                                    pressure_compensation_strategy pres_comp_strat);
+
 typedef uint32_t tims_convert_fun_t(uint64_t file_hndl, int64_t frame_id, const double *tofs, double *mzs, uint32_t arr_size);
 
 typedef uint32_t tims_scan2inv_ion_mobility_fun_t(uint64_t file_hndl, int64_t frame_id, const double *tofs, double *mzs, uint32_t arr_size);

--- a/opentims++/scan2inv_ion_mobility_converter.cpp
+++ b/opentims++/scan2inv_ion_mobility_converter.cpp
@@ -67,13 +67,13 @@ std::string BrukerScan2InvIonMobilityConverter::get_tims_error()
 
 BrukerScan2InvIonMobilityConverter::BrukerScan2InvIonMobilityConverter(TimsDataHandle& TDH, const std::string& lib_path) : lib_handle(lib_path), bruker_file_handle(0)
 {
-    tims_open = lib_handle.symbol_lookup<tims_open_fun_t>("tims_open");
+    tims_open = lib_handle.symbol_lookup<tims_open_v2_fun_t>("tims_open_v2");
     tims_get_last_error_string = lib_handle.symbol_lookup<tims_get_last_error_string_fun_t>("tims_get_last_error_string");
     tims_close = lib_handle.symbol_lookup<tims_close_fun_t>("tims_close");
     tims_scannum_to_inv_ion_mobility = lib_handle.symbol_lookup<tims_convert_fun_t>("tims_scannum_to_oneoverk0");
     tims_inv_ion_mobility_to_scannum = lib_handle.symbol_lookup<tims_convert_fun_t>("tims_oneoverk0_to_scannum");
 
-    bruker_file_handle = (*tims_open)(TDH.tims_dir_path.c_str(), 0); // Recalibrated states not supported
+    bruker_file_handle = (*tims_open)(TDH.tims_dir_path.c_str(), 1, AnalyisGlobalPressureCompensation);
 
     if(bruker_file_handle == 0)
         throw std::runtime_error("tims_open(" + TDH.tims_dir_path + ") failed. Reason: " + get_tims_error());

--- a/opentims++/scan2inv_ion_mobility_converter.h
+++ b/opentims++/scan2inv_ion_mobility_converter.h
@@ -66,7 +66,7 @@ class BrukerScan2InvIonMobilityConverter final : public Scan2InvIonMobilityConve
     const LoadedLibraryHandle lib_handle;
     uint64_t bruker_file_handle;
 
-    tims_open_fun_t* tims_open;
+    tims_open_v2_fun_t* tims_open;
     tims_get_last_error_string_fun_t* tims_get_last_error_string;
     tims_close_fun_t* tims_close;
     tims_convert_fun_t* tims_scannum_to_inv_ion_mobility;

--- a/opentims++/tof2mz_converter.cpp
+++ b/opentims++/tof2mz_converter.cpp
@@ -60,13 +60,13 @@ std::string BrukerTof2MzConverter::get_tims_error()
 
 BrukerTof2MzConverter::BrukerTof2MzConverter(TimsDataHandle& TDH, const std::string& lib_path) : lib_handle(lib_path), bruker_file_handle(0)
 {
-    tims_open = lib_handle.symbol_lookup<tims_open_fun_t>("tims_open");
+    tims_open = lib_handle.symbol_lookup<tims_open_v2_fun_t>("tims_open_v2");
     tims_get_last_error_string = lib_handle.symbol_lookup<tims_get_last_error_string_fun_t>("tims_get_last_error_string");
     tims_close = lib_handle.symbol_lookup<tims_close_fun_t>("tims_close");
     tims_index_to_mz = lib_handle.symbol_lookup<tims_convert_fun_t>("tims_index_to_mz");
     tims_mz_to_index = lib_handle.symbol_lookup<tims_convert_fun_t>("tims_mz_to_index");
 
-    bruker_file_handle = (*tims_open)(TDH.tims_dir_path.c_str(), 0); // Recalibrated states not supported
+    bruker_file_handle = (*tims_open)(TDH.tims_dir_path.c_str(), 1, AnalyisGlobalPressureCompensation);
 
     if(bruker_file_handle == 0)
         throw std::runtime_error("tims_open(" + TDH.tims_dir_path + ") failed. Reason: " + get_tims_error());

--- a/opentims++/tof2mz_converter.h
+++ b/opentims++/tof2mz_converter.h
@@ -54,7 +54,7 @@ class BrukerTof2MzConverter final : public Tof2MzConverter
     const LoadedLibraryHandle lib_handle;
     uint64_t bruker_file_handle;
 
-    tims_open_fun_t* tims_open;
+    tims_open_v2_fun_t* tims_open;
     tims_get_last_error_string_fun_t* tims_get_last_error_string;
     tims_close_fun_t* tims_close;
     tims_convert_fun_t* tims_index_to_mz;


### PR DESCRIPTION
This PR implements the changes from #15 

However, some important notes:

1. It is only compatible with the most recent TIMS SDK version (2.21.0). This means the https://github.com/MatteoLacki/opentims_bruker_bridge should be updated to keep the examples working.
2. `tims_open_v2()` seems to always load the re-calibrated data, regardless of what is passed to the `recalibration` parameter.
